### PR TITLE
Add "Submitted by" feature to credit challenge contributors

### DIFF
--- a/src/app/challenges/[id]/page.tsx
+++ b/src/app/challenges/[id]/page.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
-import { getChallengeById } from "@/lib/challenges";
+import { getChallengeById, getSubmitterProfile } from "@/lib/challenges";
 import { getUserChallengeIds } from "@/lib/my-list";
 import {
   getVoteCountForChallenge,
@@ -20,6 +20,7 @@ import { MyListButton } from "@/components/my-list-button";
 import { VoteButton } from "@/components/vote-button";
 import { ChallengeNote } from "@/components/challenge-note";
 import { SaversList } from "@/components/savers-list";
+import { UserPen } from "lucide-react";
 
 const difficultyStyle: Record<string, React.CSSProperties> = {
   Easy: { background: "rgba(42, 157, 143, 0.08)", color: "#3a8a7e", border: "1px solid rgba(42, 157, 143, 0.2)" },
@@ -43,7 +44,7 @@ export default async function ChallengePage({
   const { data: { user } } = await supabase.auth.getUser();
   const isLoggedIn = !!user;
 
-  const [savedIds, voteData, userVote, userNote, savers, saveCount] =
+  const [savedIds, voteData, userVote, userNote, savers, saveCount, submitterProfile] =
     await Promise.all([
       getUserChallengeIds(),
       getVoteCountForChallenge(challenge.id),
@@ -51,6 +52,9 @@ export default async function ChallengePage({
       getUserNoteForChallenge(challenge.id),
       getAllChallengeSavers(challenge.id),
       getSaveCountForChallenge(challenge.id),
+      challenge.submitted_by
+        ? getSubmitterProfile(challenge.submitted_by)
+        : Promise.resolve(null),
     ]);
   const isSaved = savedIds.has(challenge.id);
 
@@ -78,6 +82,20 @@ export default async function ChallengePage({
               {challenge.points != null ? `${challenge.points} pts` : "— pts"}
             </span>
           </div>
+          {challenge.submitted_by && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              {submitterProfile?.avatar_url ? (
+                <img
+                  src={submitterProfile.avatar_url}
+                  alt=""
+                  className="size-5 rounded-full"
+                />
+              ) : (
+                <UserPen className="size-4" />
+              )}
+              <span>Submitted by {submitterProfile ? submitterProfile.display_name : challenge.submitted_by}</span>
+            </div>
+          )}
           <div className="flex items-start justify-between gap-4">
             <CardTitle className="text-2xl">{challenge.title}</CardTitle>
             <div className="flex items-center gap-2">

--- a/src/app/my-list/page.tsx
+++ b/src/app/my-list/page.tsx
@@ -4,6 +4,7 @@ import { getUserChallenges } from "@/lib/my-list";
 import { getVoteCounts, getUserVotes } from "@/lib/votes";
 import { getUserNoteChallengeIds } from "@/lib/notes";
 import { getSaveCounts } from "@/lib/savers";
+import { getSubmitterDisplayNames } from "@/lib/challenges";
 import { ChallengeCard } from "@/components/challenge-card";
 import type { Challenge } from "@/lib/types";
 
@@ -28,6 +29,15 @@ export default async function MyListPage() {
 
   const voteDataMap = Object.fromEntries(voteCounts);
   const userVoteMap = Object.fromEntries(userVotes);
+
+  const submitterUsernames = [
+    ...new Set(
+      savedChallenges
+        .map((item) => (item.challenges as Challenge).submitted_by)
+        .filter((s): s is string => !!s)
+    ),
+  ];
+  const submitterNames = await getSubmitterDisplayNames(submitterUsernames);
 
   return (
     <div>
@@ -57,6 +67,7 @@ export default async function MyListPage() {
               hasNote={noteIds.has(item.challenge_id)}
               saveCount={saveCounts.get(item.challenge_id) ?? 0}
               savers={[]}
+              submitterDisplayName={(item.challenges as Challenge).submitted_by ? submitterNames[(item.challenges as Challenge).submitted_by!] : undefined}
               isLoggedIn={true}
             />
           ))}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { getChallenges } from "@/lib/challenges";
+import { getChallenges, getSubmitterDisplayNames } from "@/lib/challenges";
 import { getUserChallengeIds } from "@/lib/my-list";
 import { getVoteCounts, getUserVotes } from "@/lib/votes";
 import { getUserNoteChallengeIds } from "@/lib/notes";
@@ -21,6 +21,13 @@ export default async function Home() {
       getSaveCounts(),
     ]);
 
+  const submitterUsernames = [
+    ...new Set(
+      challenges.map((c) => c.submitted_by).filter((s): s is string => !!s)
+    ),
+  ];
+  const submitterNames = await getSubmitterDisplayNames(submitterUsernames);
+
   const voteDataMap = Object.fromEntries(voteCounts);
   const userVoteMap = Object.fromEntries(userVotes);
 
@@ -40,6 +47,7 @@ export default async function Home() {
         userNoteIds={[...noteIds]}
         saveCounts={Object.fromEntries(saveCounts)}
         saversMap={{}}
+        submitterNames={submitterNames}
         isLoggedIn={isLoggedIn}
       />
     </div>

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import { getUserById, getUserChallengesByUserId } from "@/lib/users";
+import { getSubmitterDisplayNames } from "@/lib/challenges";
 import { getDisplayName } from "@/lib/types";
 import { getVoteCounts, getUserVotes } from "@/lib/votes";
 import { getSaveCounts } from "@/lib/savers";
@@ -44,6 +45,15 @@ export default async function UserProfilePage({
   const voteDataMap = Object.fromEntries(voteCounts);
   const userVoteMap = Object.fromEntries(userVotes);
   const saveCountMap = Object.fromEntries(saveCounts);
+
+  const submitterUsernames = [
+    ...new Set(
+      savedChallenges
+        .map(({ challenges: c }) => c.submitted_by)
+        .filter((s): s is string => !!s)
+    ),
+  ];
+  const submitterNames = await getSubmitterDisplayNames(submitterUsernames);
 
   return (
     <div className="mx-auto max-w-4xl">
@@ -104,6 +114,7 @@ export default async function UserProfilePage({
                 userVote={(userVoteMap[challenge.id] as 1 | -1) ?? null}
                 hasNote={noteIds.has(challenge.id)}
                 saveCount={saveCountMap[challenge.id] ?? 0}
+                submitterDisplayName={challenge.submitted_by ? submitterNames[challenge.submitted_by] : undefined}
                 isLoggedIn={isLoggedIn}
               />
             ))}

--- a/src/components/challenge-card.tsx
+++ b/src/components/challenge-card.tsx
@@ -14,6 +14,7 @@ import { MyListButton } from "@/components/my-list-button";
 import { VoteButton } from "@/components/vote-button";
 import { SaversCount } from "@/components/savers-count";
 import { StickyNote } from "lucide-react";
+import { SubmittedByIcon } from "@/components/submitted-by";
 
 const difficultyStyle: Record<string, React.CSSProperties> = {
   Easy: { background: "rgba(42, 157, 143, 0.08)", color: "#3a8a7e", border: "1px solid rgba(42, 157, 143, 0.2)" },
@@ -30,6 +31,7 @@ export function ChallengeCard({
   hasNote = false,
   saveCount = 0,
   savers = [],
+  submitterDisplayName,
   isLoggedIn = false,
 }: {
   challenge: Challenge;
@@ -40,6 +42,7 @@ export function ChallengeCard({
   hasNote?: boolean;
   saveCount?: number;
   savers?: ChallengeSaver[];
+  submitterDisplayName?: string;
   isLoggedIn?: boolean;
 }) {
   return (
@@ -69,6 +72,13 @@ export function ChallengeCard({
             </div>
           </div>
           <div className="flex flex-wrap items-center gap-1.5 pt-1">
+            {challenge.submitted_by && (
+              <SubmittedByIcon
+                username={challenge.submitted_by}
+                displayName={submitterDisplayName}
+                size="sm"
+              />
+            )}
             <Badge variant="outline" className="text-xs">
               {challenge.category}
             </Badge>

--- a/src/components/challenge-list.tsx
+++ b/src/components/challenge-list.tsx
@@ -23,6 +23,7 @@ export function ChallengeList({
   userNoteIds,
   saveCounts,
   saversMap,
+  submitterNames,
   isLoggedIn = false,
 }: {
   challenges: Challenge[];
@@ -32,6 +33,7 @@ export function ChallengeList({
   userNoteIds?: number[];
   saveCounts?: Record<number, number>;
   saversMap?: Record<number, ChallengeSaver[]>;
+  submitterNames?: Record<string, string>;
   isLoggedIn?: boolean;
 }) {
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
@@ -125,6 +127,7 @@ export function ChallengeList({
               userVote={(userVotes[challenge.id] as 1 | -1) ?? null}
               hasNote={userNoteIds?.includes(challenge.id)}
               saveCount={saveCounts?.[challenge.id] ?? 0}
+              submitterDisplayName={challenge.submitted_by ? submitterNames?.[challenge.submitted_by] : undefined}
               isLoggedIn={isLoggedIn}
             />
           );

--- a/src/components/submitted-by.tsx
+++ b/src/components/submitted-by.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { UserPen } from "lucide-react";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+
+interface SubmittedByIconProps {
+  username: string;
+  displayName?: string;
+  size?: "sm" | "default";
+}
+
+export function SubmittedByIcon({ username, displayName, size = "sm" }: SubmittedByIconProps) {
+  const iconSize = size === "sm" ? "size-3.5" : "size-4";
+  const textSize = size === "sm" ? "text-xs" : "text-sm";
+
+  return (
+    <HoverCard openDelay={200} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
+          className={`flex items-center gap-1 text-muted-foreground transition-colors hover:text-foreground ${textSize}`}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+        >
+          <UserPen className={iconSize} />
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent
+        className="w-auto p-3"
+        side="top"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <p className="text-sm font-medium">Submitted by {displayName ?? username}</p>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}

--- a/src/lib/challenges.ts
+++ b/src/lib/challenges.ts
@@ -1,5 +1,5 @@
 import { createClient } from "./supabase/server";
-import { Challenge } from "./types";
+import { Challenge, UserProfile } from "./types";
 
 export async function getChallenges(): Promise<Challenge[]> {
   const supabase = await createClient();
@@ -24,6 +24,56 @@ export async function getChallengeById(
 
   if (error) return null;
   return data as Challenge;
+}
+
+export async function getSubmitterProfile(
+  discordUsername: string
+): Promise<UserProfile | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("id, display_name, avatar_url, guild_nickname")
+    .or(
+      `display_name.eq.${discordUsername},guild_nickname.eq.${discordUsername}`
+    )
+    .limit(1)
+    .maybeSingle();
+
+  if (error || !data) return null;
+  return data as UserProfile;
+}
+
+/** Batch-resolve submitted_by usernames to display names */
+export async function getSubmitterDisplayNames(
+  usernames: string[]
+): Promise<Record<string, string>> {
+  if (usernames.length === 0) return {};
+  const supabase = await createClient();
+
+  // Find profiles where display_name or guild_nickname matches any username
+  const filters = usernames
+    .map((u) => `display_name.eq.${u},guild_nickname.eq.${u}`)
+    .join(",");
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("display_name, guild_nickname")
+    .or(filters);
+
+  if (error || !data) return {};
+
+  const map: Record<string, string> = {};
+  for (const profile of data) {
+    // Map the matched username (guild_nickname or display_name) to the display_name
+    for (const username of usernames) {
+      if (
+        profile.guild_nickname === username ||
+        profile.display_name === username
+      ) {
+        map[username] = profile.display_name;
+      }
+    }
+  }
+  return map;
 }
 
 export async function getCategories(): Promise<string[]> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,6 +7,7 @@ export interface Challenge {
   completion_criteria: string;
   category: string;
   points: number | null;
+  submitted_by: string | null;
 }
 
 export type UserVoteType = 1 | -1 | null;

--- a/supabase/migrations/006_submitted_by.sql
+++ b/supabase/migrations/006_submitted_by.sql
@@ -1,0 +1,2 @@
+-- Add submitted_by column to track who proposed each challenge
+ALTER TABLE challenges ADD COLUMN submitted_by TEXT;


### PR DESCRIPTION
Shows a small icon with hover card tooltip on challenge cards and a full display (avatar + name) on the detail page. Submitter discord usernames are resolved to display names via profile lookup. Seed script now loads both CSVs and links test users to submitter usernames via guild_nickname.